### PR TITLE
fix lookup dataset urls

### DIFF
--- a/holo/test_functions/lookup/_dhfr.py
+++ b/holo/test_functions/lookup/_dhfr.py
@@ -71,7 +71,7 @@ class DHFRLookup(AbstractLookup):
                 - sorted_seqs: List of sequences sorted by descending score
         """
         # Remote URL for the data
-        url = "https://raw.githubusercontent.com/skalyaanamoorthy/variationalsearch/main/data/DHFR/DHFR_fitness_data_wt.csv"
+        url = "https://media.githubusercontent.com/media/francesding/variationalsearch/refs/heads/main/data/DHFR/DHFR_fitness_data_wt.csv"
 
         # Use pooch to download and cache the data
         file_path = pooch.retrieve(

--- a/holo/test_functions/lookup/_tfbind8.py
+++ b/holo/test_functions/lookup/_tfbind8.py
@@ -66,7 +66,7 @@ class TFBIND8Lookup(AbstractLookup):
                 - sorted_seqs: List of sequences sorted by descending score
         """
         # Remote URL for the data
-        url = "https://raw.githubusercontent.com/skalyaanamoorthy/variationalsearch/main/data/TFBIND8/tf_bind_8.csv"
+        url = "https://media.githubusercontent.com/media/francesding/variationalsearch/refs/heads/main/data/TFBIND8/tf_bind_8.csv"
 
         # Use pooch to download and cache the data
         try:

--- a/holo/test_functions/lookup/_trpb.py
+++ b/holo/test_functions/lookup/_trpb.py
@@ -75,7 +75,7 @@ class TRPBLookup(AbstractLookup):
                 - sorted_seqs: List of sequences sorted by descending score
         """
         # Remote URL for the data
-        url = "https://raw.githubusercontent.com/skalyaanamoorthy/variationalsearch/main/data/TRPB/four-site_simplified_AA_data.csv"
+        url = "https://media.githubusercontent.com/media/francesding/variationalsearch/refs/heads/main/data/TRPB/four-site_simplified_AA_data.csv"
 
         # Use pooch to download and cache the data
         file_path = pooch.retrieve(


### PR DESCRIPTION
Updated urls for the lookup test functions because the previous urls were broken.

The urls now point to [this fork](https://github.com/francesding/variationalsearch) of the [variationalsearch](https://github.com/csiro-funml/variationalsearch) repo.